### PR TITLE
Move crontab to recommended location

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ This plugin provides hooks:
 This plugin allows you to store configuration files which reside in the dokku app directory, such as ENV, inside the app's git repository.
 
 For example, say you want to include a file called DOCKER_OPTIONS for the [Docker options plugin](https://github.com/dyson/dokku-docker-options). In the root directory of your app repository, create a directory called `.dokku` and put the files in there. This plugin will copy those files into `$DOKKU_ROOT/$APP/` before building the app.
+
+Optionally if you place a `crontab` in `.dokku` it will move this crontab file to `/etc/cron.d/$APP`

--- a/install
+++ b/install
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail;
+[[ $DOKKU_TRACE ]] && set -x
+
+
+echo "%dokku ALL=(ALL) NOPASSWD: /bin/cp, /usr/sbin/service cron restart" > /etc/sudoers.d/dokku-supply-config
+chmod 0440 "/etc/sudoers.d/dokku-supply-config"

--- a/post-extract
+++ b/post-extract
@@ -10,6 +10,12 @@ suppy-config-post-extract() {
   if [[ -d "$TMPDIR/.dokku" ]] && [[ "$(ls -A "$TMPDIR/.dokku")" ]]; then
     output=$(cp -r "$TMPDIR/.dokku/." "$DOKKU_ROOT/$APP")
     dokku_log_verbose_quiet "$output"
+
+    if [[ "$(ls -A "$TMPDIR/.dokku/crontab")" ]]; then
+        output=$(sudo cp -r "$TMPDIR/.dokku/crontab" "/etc/cron.d/$APP")
+        dokku_log_verbose_quiet "$output"
+        sudo service cron restart
+    fi
   fi
 }
 


### PR DESCRIPTION
Fixes the following issue #6. This PR will move a file `crontab` to the recommended location for crontab. The user of the plugin will need to add two extra permissions in sudoers to let the dokku user overwrite the crontab correctly the next time their application is deployed. 